### PR TITLE
Redesign Souls tab on a loadout form

### DIFF
--- a/VBusiness/Souls/TitanSouls/StridingTitanSoul.cs
+++ b/VBusiness/Souls/TitanSouls/StridingTitanSoul.cs
@@ -13,19 +13,17 @@ namespace VBusiness.Souls
 		public override void ActivateUniqueEffect()
 		{
 			Loadout.Stats.Attack += 20;
-			Loadout.Stats.UpdateAttackSpeed("stitan", 20);
 			Loadout.Stats.UpdateHealth("Core", 20);
 			Loadout.Stats.UpdateShields("Core", 20);
-			VEntityFramework.ErrorReporter.ReportDebug("Check how this works for health and shields.");
-			VEntityFramework.ErrorReporter.ReportDebug("Check how this works for acceleration");
+			Loadout.Stats.UpdateAcceleration("stitan", 20); // this also updates attack speed, haven't fully tested this.
 		}
 
 		public override void DeactivateUniqueEffect()
 		{
 			Loadout.Stats.Attack -= 20;
-			Loadout.Stats.UpdateAttackSpeed("stitan", -20);
 			Loadout.Stats.UpdateShields("Core", -20);
 			Loadout.Stats.UpdateHealth("Core", -20);
+			Loadout.Stats.UpdateAcceleration("stitan", -20);
 		}
 	}
 }

--- a/VEnitity/Model/VSoul.cs
+++ b/VEnitity/Model/VSoul.cs
@@ -248,7 +248,7 @@ namespace VEntityFramework.Model
 
 		#region UniqueName
 
-		public string UniqueName => IsUnique ? $"{Rarity} Soul of {Type.GetDescription()}" : $"Regular {Rarity} Soul";
+		public string UniqueName => IsUnique ? $"{Rarity.GetDescription()} Soul of {Type.GetDescription()}" : $"Regular {Rarity.GetDescription()} Soul";
 
 		#endregion
 
@@ -290,6 +290,6 @@ namespace VEntityFramework.Model
 
 		#endregion
 
-		public const SoulType HighestNonUniqueSoul = SoulType.HalfPitchBlack; 
+		public const SoulType HighestNonUniqueSoul = SoulType.HalfPitchBlack;
 	}
 }

--- a/VUserInterface/SoulControl.Designer.cs
+++ b/VUserInterface/SoulControl.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Windows.Forms;
+﻿using System.ComponentModel;
 using VEntityFramework.Model;
 using VUserInterface.CommonControls;
 
@@ -34,14 +32,6 @@ namespace VUserInterface
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.AttackLabel = new VLabel();
-			this.AttackSpeedLabel = new VLabel();
-			this.VitalsLabel = new VLabel();
-			this.ArmorLabel = new VLabel();
-			this.CriticalChanceLabel = new VLabel();
-			this.CriticalDamageLabel = new VLabel();
-			this.MineralsLabel = new VLabel();
-			this.KillsLabel = new VLabel();
 			this.AddNewSoulButton = new DPIButton();
 			this.SoulComboBox = new System.Windows.Forms.ComboBox();
 			this.BindingSource = new VBindingSource();
@@ -51,120 +41,33 @@ namespace VUserInterface
 			// BindingSource
 			//
 			this.BindingSource.DataSource = typeof(VSoul);
-			// 
-			// AttackLabel
-			// 
-			this.AttackLabel.AutoSize = true;
-			this.AttackLabel.Caption = "Attack";
-			this.AttackLabel.DataBindings.Add("Text", BindingSource, "Attack");
-			this.AttackLabel.Location = DPIScalingHelper.GetScaledPoint(120, 60);
-			this.AttackLabel.Name = "AttackLabel";
-			this.AttackLabel.TabIndex = 0;
-			// 
-			// AttackSpeedLabel
-			// 
-			this.AttackSpeedLabel.AutoSize = true;
-			this.AttackSpeedLabel.Caption = "Attack Speed";
-			this.AttackSpeedLabel.DataBindings.Add("Text", BindingSource, "AttackSpeed");
-			this.AttackSpeedLabel.Location = DPIScalingHelper.GetScaledPoint(120, 80);
-			this.AttackSpeedLabel.Name = "AttackSpeedLabel";
-			this.AttackSpeedLabel.TabIndex = 0;
-			// 
-			// VitalsLabel
-			// 
-			this.VitalsLabel.AutoSize = true;
-			this.VitalsLabel.Caption = "Vitals";
-			this.VitalsLabel.DataBindings.Add("Text", BindingSource, "Vitals");
-			this.VitalsLabel.Location = DPIScalingHelper.GetScaledPoint(120, 100);
-			this.VitalsLabel.Name = "VitalsLabel";
-			this.VitalsLabel.TabIndex = 0;
-			// 
-			// ArmorLabel
-			// 
-			this.ArmorLabel.AutoSize = true;
-			this.ArmorLabel.Caption = "Armor";
-			this.ArmorLabel.DataBindings.Add("Text", BindingSource, "Armor");
-			this.ArmorLabel.Location = DPIScalingHelper.GetScaledPoint(120, 120);
-			this.ArmorLabel.Name = "ArmorLabel";
-			this.ArmorLabel.TabIndex = 0;
-			// 
-			// CriticalChanceLabel
-			// 
-			this.CriticalChanceLabel.AutoSize = true;
-			this.CriticalChanceLabel.Caption = "Crit Chance";
-			this.CriticalChanceLabel.DataBindings.Add("Text", BindingSource, "CriticalChance");
-			this.CriticalChanceLabel.Location = DPIScalingHelper.GetScaledPoint(120, 140);
-			this.CriticalChanceLabel.Name = "CriticalChanceLabel";
-			this.CriticalChanceLabel.TabIndex = 0;
-			// 
-			// CriticalDamageLabel
-			// 
-			this.CriticalDamageLabel.AutoSize = true;
-			this.CriticalDamageLabel.Caption = "Crit Damage";
-			this.CriticalDamageLabel.DataBindings.Add("Text", BindingSource, "CriticalDamage");
-			this.CriticalDamageLabel.Location = DPIScalingHelper.GetScaledPoint(120, 160);
-			this.CriticalDamageLabel.Name = "CriticalDamageLabel";
-			this.CriticalDamageLabel.TabIndex = 0;
-			// 
-			// MineralsLabel
-			// 
-			this.MineralsLabel.AutoSize = true;
-			this.MineralsLabel.Caption = "Minerals";
-			this.MineralsLabel.DataBindings.Add("Text", BindingSource, "Minerals");
-			this.MineralsLabel.Location = DPIScalingHelper.GetScaledPoint(120, 180);
-			this.MineralsLabel.Name = "MineralsLabel";
-			this.MineralsLabel.TabIndex = 0;
-			// 
-			// KillsLabel
-			// 
-			this.KillsLabel.Caption = "Kills";
-			this.KillsLabel.DataBindings.Add("Text", BindingSource, "Kills");
-			this.KillsLabel.Location = DPIScalingHelper.GetScaledPoint(120, 200);
-			this.KillsLabel.Name = "KillsLabel";
-			this.KillsLabel.TabIndex = 0;
 			//
 			// AddNewSoulButton
 			//
 			this.AddNewSoulButton.Click += AddNewSoulButton_Click;
-			this.AddNewSoulButton.Location = DPIScalingHelper.GetScaledPoint(15, 230);
+			this.AddNewSoulButton.Location = DPIScalingHelper.GetScaledPoint(375, 20);
 			this.AddNewSoulButton.Name = "AddNewSoulButton";
-			this.AddNewSoulButton.Size = DPIScalingHelper.GetScaledSize(135, 25);
-			this.AddNewSoulButton.Text = "Add New";
+			this.AddNewSoulButton.Size = DPIScalingHelper.GetScaledSize(25, 25);
+			this.AddNewSoulButton.Text = "+";
 			//
 			// SoulComboBox
 			//
-			this.SoulComboBox.Location = DPIScalingHelper.GetScaledPoint(15, 30);
-			this.SoulComboBox.Size = DPIScalingHelper.GetScaledSize(135, 25);
+			this.SoulComboBox.Location = DPIScalingHelper.GetScaledPoint(15, 20);
+			this.SoulComboBox.Size = DPIScalingHelper.GetScaledSize(350, 25);
 			this.SoulComboBox.DataSource = SoulList;
 			this.SoulComboBox.SelectedValueChanged += SoulChanged;
 			// 
 			// SoulControl
 			// 
 			this.Controls.Add(this.SoulComboBox);
-			this.Controls.Add(this.KillsLabel);
-			this.Controls.Add(this.MineralsLabel);
-			this.Controls.Add(this.CriticalDamageLabel);
-			this.Controls.Add(this.CriticalChanceLabel);
-			this.Controls.Add(this.ArmorLabel);
-			this.Controls.Add(this.VitalsLabel);
-			this.Controls.Add(this.AttackSpeedLabel);
-			this.Controls.Add(this.AttackLabel);
 			this.Controls.Add(this.AddNewSoulButton);
 			this.Name = "SoulForm";
-			this.Size = DPIScalingHelper.GetScaledSize(163, 270);
+			this.Size = DPIScalingHelper.GetScaledSize(410, 55);
 			((ISupportInitialize)this.BindingSource).EndInit();
 		}
 
 		#endregion
 
-		private VLabel AttackLabel;
-		private VLabel AttackSpeedLabel;
-		private VLabel VitalsLabel;
-		private VLabel ArmorLabel;
-		private VLabel CriticalChanceLabel;
-		private VLabel CriticalDamageLabel;
-		private VLabel MineralsLabel;
-		private VLabel KillsLabel;
 		private DPIButton AddNewSoulButton;
 		private System.Windows.Forms.ComboBox SoulComboBox;
 		private System.Windows.Forms.BindingSource BindingSource;

--- a/VUserInterface/VLoadoutForm.Designer.cs
+++ b/VUserInterface/VLoadoutForm.Designer.cs
@@ -206,7 +206,7 @@ namespace VUserInterface
 			//
 			// SoulsControl
 			//
-			this.SoulsControl.Location = DPIScalingHelper.GetScaledPoint(5, 40);
+			this.SoulsControl.Location = DPIScalingHelper.GetScaledPoint(0, 10);
 			this.SoulsControl.DataBindings.Add("Souls", this.bindingSource, "Souls");
 			this.SoulsControl.Text = "Soul";
 			//

--- a/VUserInterface/VLoadoutSoulsControl.Designer.cs
+++ b/VUserInterface/VLoadoutSoulsControl.Designer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows.Forms;
 using VBusiness.Profile;
-using VBusiness.Souls;
 using VEntityFramework.Model;
 using VUserInterface.CommonControls;
 
@@ -36,6 +35,9 @@ namespace VUserInterface
 		{
 			components = new System.ComponentModel.Container();
 			this.bindingSource = new VBindingSource();
+			this.SoulsCostLabel = new VLabel();
+			this.TotalCostLabel = new VLabel();
+			this.RemainingCostLabel = new VLabel();
 			this.Soul1Control = new SoulControl();
 			this.Soul2Control = new SoulControl();
 			this.Soul3Control = new SoulControl();
@@ -48,18 +50,43 @@ namespace VUserInterface
 			//
 			this.bindingSource.DataSource = typeof(VLoadoutSouls);
 			//
+			// PageCostLabel;
+			//
+			this.SoulsCostLabel.DataBindings.Add("Text", bindingSource, "SoulCosts");
+			this.SoulsCostLabel.Caption = "Cost of Souls:";
+			this.SoulsCostLabel.Location = DPIScalingHelper.GetScaledPoint(100, 0);
+			this.SoulsCostLabel.Name = "PageCostLabel";
+			this.SoulsCostLabel.Size = DPIScalingHelper.GetScaledSize(100, 30);
+			//
+			// TotalCostLabel;
+			//
+			this.TotalCostLabel.DataBindings.Add("Text", bindingSource, "Loadout.PerkPointsCost");
+			this.TotalCostLabel.Caption = "Total Loadout Cost:";
+			this.TotalCostLabel.Location = DPIScalingHelper.GetScaledPoint(300, 0);
+			this.TotalCostLabel.Name = "TotalCostLabel";
+			this.TotalCostLabel.Size = DPIScalingHelper.GetScaledSize(100, 30);
+			//
+			// RemainingCostLabel;
+			//
+			this.RemainingCostLabel.DataBindings.Add("Text", bindingSource, "Loadout.RemainingPerkPoints");
+			this.RemainingCostLabel.Caption = "Available PP:";
+			this.RemainingCostLabel.Location = DPIScalingHelper.GetScaledPoint(500, 0);
+			this.RemainingCostLabel.Name = "RemainingCostLabel";
+			this.RemainingCostLabel.Size = DPIScalingHelper.GetScaledSize(100, 30);
+			//
 			// Soul1Control
 			//
 			this.Soul1Control.DataBindings.Add("Soul", bindingSource, "Soul1");
 			this.Soul1Control.DataBindings.Add("SoulCollection", bindingSource, ".");
-			this.Soul1Control.Location = DPIScalingHelper.GetScaledPoint(35, 20);
+			this.Soul1Control.Location = DPIScalingHelper.GetScaledPoint(85, 30);
 			this.Soul1Control.OnSoulChanged += Soul1Control_OnSoulChanged;
 			//
 			// Soul2Control
 			//
 			this.Soul2Control.DataBindings.Add("Soul", bindingSource, "Soul2");
 			this.Soul2Control.DataBindings.Add("SoulCollection", bindingSource, ".");
-			this.Soul2Control.Location = DPIScalingHelper.GetScaledPoint(208, 20);
+			this.Soul2Control.Enabled = Profile.GetProfile().Rank >= PlayerRank.SuperCrusader;
+			this.Soul2Control.Location = DPIScalingHelper.GetScaledPoint(85, 90);
 			this.Soul2Control.OnSoulChanged += Soul2Control_OnSoulChanged;
 			//
 			// Soul3Control
@@ -67,15 +94,14 @@ namespace VUserInterface
 			this.Soul3Control.DataBindings.Add("Soul", bindingSource, "Soul3");
 			this.Soul3Control.DataBindings.Add("SoulCollection", bindingSource, ".");
 			this.Soul3Control.Enabled = false;
-			this.Soul3Control.Location = DPIScalingHelper.GetScaledPoint(381, 20);
+			this.Soul3Control.Location = DPIScalingHelper.GetScaledPoint(85, 150);
 			this.Soul3Control.OnSoulChanged += Soul3Control_OnSoulChanged;
-			this.Soul3Control.Visible = false;
 			//
 			// SoulPowerButton
 			//
 			this.SoulPowerButton.Click += VLoadoutSoulsControl_Click;
 			this.SoulPowerButton.Size = DPIScalingHelper.GetScaledSize(150, 30);
-			this.SoulPowerButton.Location = DPIScalingHelper.GetScaledPoint(420, 40);
+			this.SoulPowerButton.Location = DPIScalingHelper.GetScaledPoint(85, 220);
 			this.SoulPowerButton.Name = "SoulPowerButton";
 			this.SoulPowerButton.Text = "Soul Powers";
 			//
@@ -83,27 +109,30 @@ namespace VUserInterface
 			//
 			this.SoulPower1Label.Caption = "Soul Power 1:";
 			this.SoulPower1Label.DataBindings.Add("Text", bindingSource, "SoulPower1");
-			this.SoulPower1Label.Location = DPIScalingHelper.GetScaledPoint(470, 100);
+			this.SoulPower1Label.Location = DPIScalingHelper.GetScaledPoint(170, 260);
 			this.SoulPower1Label.Name = "SoulPowerButton";
 			this.SoulPower1Label.Visible = Profile.GetProfile().SoulCollection.PowerSoulsCount > 0;
 			//
-			// SoulPower1Label
+			// SoulPower2Label
 			//
 			this.SoulPower2Label.Caption = "Soul Power 2:";
 			this.SoulPower2Label.DataBindings.Add("Text", bindingSource, "SoulPower2");
-			this.SoulPower2Label.Location = DPIScalingHelper.GetScaledPoint(470, 130);
+			this.SoulPower2Label.Location = DPIScalingHelper.GetScaledPoint(170, 290);
 			this.SoulPower2Label.Name = "SoulPowerButton";
 			this.SoulPower2Label.Visible = Profile.GetProfile().SoulCollection.PowerSoulsCount > 1;
 			//
 			// VSoulCollectionControl
 			//
+			this.Controls.Add(TotalCostLabel);
+			this.Controls.Add(SoulsCostLabel);
+			this.Controls.Add(RemainingCostLabel);
 			this.Controls.Add(Soul1Control);
 			this.Controls.Add(Soul2Control);
 			this.Controls.Add(Soul3Control);
 			this.Controls.Add(SoulPowerButton);
 			this.Controls.Add(SoulPower1Label);
 			this.Controls.Add(SoulPower2Label);
-			this.Size = DPIScalingHelper.GetScaledSize(589, 272);
+			this.Size = DPIScalingHelper.GetScaledSize(589, 330);
 			((System.ComponentModel.ISupportInitialize)(this.bindingSource)).EndInit();
 		}
 
@@ -116,5 +145,8 @@ namespace VUserInterface
 		DPIButton SoulPowerButton;
 		VLabel SoulPower1Label;
 		VLabel SoulPower2Label;
+		VLabel SoulsCostLabel;
+		VLabel TotalCostLabel;
+		VLabel RemainingCostLabel;
 	}
 }


### PR DESCRIPTION
- Soul names are correctly populated with spaces
- Soul control drop box has been expanded to see the full soul name
- Stats of the souls have been removed from the selection display
- Labels describing the cost of the souls, the cost of the loadout and the available pp have been added